### PR TITLE
chore: update bots/workflows pr titles to follow conventional commits spec

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,9 @@ updates:
       interval: "weekly"
     open-pull-requests-limit: 10
     target-branch: main
+    commit_message:
+      prefix: "chore"
+      include_scope: true
 
   - package-ecosystem: "docker"
     directory: "/"
@@ -13,6 +16,9 @@ updates:
       interval: "weekly"
     open-pull-requests-limit: 10
     target-branch: main
+    commit_message:
+      prefix: "chore"
+      include_scope: true
 
   - package-ecosystem: "gomod"
     directory: /
@@ -20,3 +26,6 @@ updates:
       interval: "weekly"
     open-pull-requests-limit: 10
     target-branch: main
+    commit_message:
+      prefix: "chore"
+      include_scope: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ ci:
     for more information, see https://pre-commit.ci
   autofix_prs: true
   autoupdate_branch: 'main'
-  autoupdate_commit_msg: '[pre-commit.ci] pre-commit autoupdate'
+  autoupdate_commit_msg: 'chore(pre-commit.ci): pre-commit autoupdate'
   autoupdate_schedule: weekly
   skip: []
   submodules: false


### PR DESCRIPTION
### Description

Solves issue: N/A

ensure that pr titles from bots/workflows follow the conventional commits spec.

### Changelog

- update `dependabot` to use the conventional commits spec.
- update `pre-commit ci` to use the conventional commits spec.

### Checklist

- [ ] This change has been unit tested.
